### PR TITLE
initial version of SCAN_INSERTION bus definition

### DIFF
--- a/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
+++ b/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
@@ -1,0 +1,60 @@
+{
+  abstractionDefinition: {
+    vendor: 'sifive.com',
+    library: 'TEST',
+    name: 'SCAN_INSERTION_rtl',
+    version: '0.1.0',
+    busType: {
+      vendor: 'sifive.com',
+      library: 'TEST',
+      name: 'SCAN_INSERTION',
+      version: '0.1.0',
+    },
+    ports: {
+      CLOCK: {
+        description: 'Clock used during scan',
+        isClock: true,
+        wire: {
+          onMaster: {width: 1, direction: 'out', presence: 'required'},
+          onSlave:  {width: 1, direction: 'in', presence: 'required'}
+        }
+      },
+      CLOCK_EN: {
+        description: 'Clock enable on the scan clock path',
+        isClock: true,
+        wire: {
+          onMaster: {width: 1, direction: 'out'},
+          onSlave:  {width: 1, direction: 'in'}
+        }
+      },
+      RESET: {
+        description: 'Reset used during scan (active high)',
+        wire: {
+          onMaster: {width: 1, direction: 'out'},
+          onSlave:  {width: 1, direction: 'in'}
+        }
+      },
+      RESETn: {
+        description: 'Reset used during scan (active low)',
+        wire: {
+          onMaster: {width: 1, direction: 'out'},
+          onSlave:  {width: 1, direction: 'in'}
+        }
+      },
+      TEST_MODE: {
+        description: 'switch into test mode (active high)',
+        wire: {
+          onMaster: {width: 1, direction: 'out'},
+          onSlave:  {width: 1, direction: 'in'}
+        }
+      },
+      TEST_MODEn: {
+        description: 'switch into test mode (active low)',
+        wire: {
+          onMaster: {width: 1, direction: 'out'},
+          onSlave:  {width: 1, direction: 'in'}
+        }
+      },
+    }
+  }
+}

--- a/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
+++ b/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
@@ -21,7 +21,6 @@
       },
       CLOCK_EN: {
         description: 'Clock enable on the scan clock path',
-        isClock: true,
         wire: {
           onMaster: {width: 1, direction: 'out'},
           onSlave:  {width: 1, direction: 'in'}

--- a/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
+++ b/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
@@ -41,38 +41,31 @@
         }
       },
       TEST_MODE: {
-        description: 'switch into test mode (active high)',
+        description: 'switch into test mode',
         wire: {
-          onMaster: {width: 1, direction: 'out'},
-          onSlave:  {width: 1, direction: 'in'}
-        }
-      },
-      TEST_MODEn: {
-        description: 'switch into test mode (active low)',
-        wire: {
-          onMaster: {width: 1, direction: 'out'},
-          onSlave:  {width: 1, direction: 'in'}
+          onMaster: {direction: 'out'},
+          onSlave:  {direction: 'in'}
         }
       },
       SE: {
         description: 'scan chain enable',
         wire: {
-          onMaster: {width: 1, direction: 'out'},
-          onSlave:  {width: 1, direction: 'in'}
+          onMaster: {direction: 'out'},
+          onSlave:  {direction: 'in'}
         }
       },
       SI: {
         description: 'scan chain input',
         wire: {
-          onMaster: {width: 1, direction: 'out'},
-          onSlave:  {width: 1, direction: 'in'}
+          onMaster: {direction: 'out'},
+          onSlave:  {direction: 'in'}
         }
       },
       SO: {
         description: 'scan chain output',
         wire: {
-          onMaster: {width: 1, direction: 'in'},
-          onSlave:  {width: 1, direction: 'out'}
+          onMaster: {direction: 'in'},
+          onSlave:  {direction: 'out'}
         }
       },
     }

--- a/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
+++ b/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
@@ -54,6 +54,27 @@
           onSlave:  {width: 1, direction: 'in'}
         }
       },
+      SE: {
+        description: 'scan chain enable',
+        wire: {
+          onMaster: {width: 1, direction: 'out'},
+          onSlave:  {width: 1, direction: 'in'}
+        }
+      },
+      SI: {
+        description: 'scan chain input',
+        wire: {
+          onMaster: {width: 1, direction: 'out'},
+          onSlave:  {width: 1, direction: 'in'}
+        }
+      },
+      SO: {
+        description: 'scan chain output',
+        wire: {
+          onMaster: {width: 1, direction: 'in'},
+          onSlave:  {width: 1, direction: 'out'}
+        }
+      },
     }
   }
 }

--- a/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
+++ b/specs/sifive.com/TEST/SCAN_INSERTION/0.1.0/SCAN_INSERTION_rtl.json5
@@ -33,13 +33,6 @@
           onSlave:  {width: 1, direction: 'in'}
         }
       },
-      RESETn: {
-        description: 'Reset used during scan (active low)',
-        wire: {
-          onMaster: {width: 1, direction: 'out'},
-          onSlave:  {width: 1, direction: 'in'}
-        }
-      },
       TEST_MODE: {
         description: 'switch into test mode',
         wire: {


### PR DESCRIPTION
New bus definition.
To be consumed by DFT scan insertion tools.
See examples here: https://observablehq.com/@drom/scan-bus-definition